### PR TITLE
task_autoload_setting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'owlcarousel-rails'
 # グラフ機能 rubyだけで記述が可能
 gem 'chartkick'
 
+# ファイルの変更を検知してそれをフックに何か処理ができるgemとのこと
+gem 'listen', '>= 3.0.5', '< 3.2'
+
 group :production do
   # 開発環境では、DBにはSQLiteを利用していたが、AWSで動作させる際にはMySQLを利用
   gem 'mysql2'
@@ -86,7 +89,6 @@ end
 
 group :development do
   gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   # コーディングスタイルをチェックするための静的解析ツール

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,10 @@ module Relearn
     config.active_record.default_timezone = :local
     # コントローラーに対応するヘルパーのみ呼び出せる
     config.action_controller.include_all_helpers = false
+    # パスをタスク作成時のリクエストのたびにロード設定
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    # パスを、rails起動の際にロードする設定
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"] 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
自動化させるためのrakeタスク実行時にdevelop環境で動いてしまうための対処として
production環境ではautoloadが必須になるので設定追加