### PR TITLE
[Fix]Editor:Detect Indentation設定解除 #305 fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,26 +1,26 @@
 class ApplicationController < ActionController::Base
-	# CSRF対策 サイトへのコード攻撃を防ぐ
-	protect_from_forgery with: :exception
-	# devise動作時の利用カラムを制限する
-	before_action :configure_permitted_parameters, if: :devise_controller?
-	helper_method :logged_in?
+  # CSRF対策 サイトへのコード攻撃を防ぐ
+  protect_from_forgery with: :exception
+  # devise動作時の利用カラムを制限する
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  helper_method :logged_in?
 
-	protected
+  protected
 
-	def configure_permitted_parameters
-		added_attrs = [:name, :email, :password, :password_confirmation]
-		devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
-		devise_parameter_sanitizer.permit :account_update, keys: added_attrs
-		devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
-	end
+  def configure_permitted_parameters
+    added_attrs = [:name, :email, :password, :password_confirmation]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+    devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
+  end
 
-	def logged_in?
-		!session[:user_id].nil?
-	end
+  def logged_in?
+    !session[:user_id].nil?
+  end
 
-	def authenticate
-		return if logged_in?
+  def authenticate
+    return if logged_in?
 
-		redirect_to root_path
-	end
+    redirect_to root_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 	end
 
 	def logged_in?
-    !session[:user_id].nil?
+		!session[:user_id].nil?
 	end
 
 	def authenticate


### PR DESCRIPTION
VScode上でのEditor:Detect Indentationの設定のチェックを解除
(VSCodeで、Tabを押した時に、インデントを、半角スペース埋めにするか、Tab埋めにするかの設定)
チェックが入っていると半角スペース埋めになる。